### PR TITLE
Remove extraneous newlines from the saga template

### DIFF
--- a/templates/saga/document.erb
+++ b/templates/saga/document.erb
@@ -11,18 +11,18 @@ USER STORIES
 <% stories.each do |header, stories| -%>
 <% if header.strip == '' %>
 <% else -%>
-<%= "\n#{header}\n\n" %>
+<%= "\n#{header}\n\n" -%>
 <% end -%>
 <% stories.each do |story| -%>
-<%= format_story(story) %>
+<%= format_story(story) -%>
 <% end -%>
 <% end -%>
 <% definitions.each do |header, definitions| -%>
 <% if header.strip == '' -%>
 <% else -%>
-<%= "\n#{header}\n\n" %>
-<% end %>
+<%= "\n#{header}\n\n" -%>
+<% end -%>
 <% definitions.each do |definition| -%>
 <%= format_definition(definition) %>
-<% end %>
+<% end -%>
 <% end %>


### PR DESCRIPTION
Allows the autofill feature to be used without adding blank lines.